### PR TITLE
Added the fileextswitch.ts command support

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "activationEvents": [
         "onCommand:fileextswitch.css",
         "onCommand:fileextswitch.html",
-        "onCommand:fileextswitch.js"
+        "onCommand:fileextswitch.js",
+        "onCommand:fileextswitch.ts"
     ],
     "main": "./out/src/extension",
     "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ export function activate(context: vscode.ExtensionContext) {
     addCommand(context, ['.css', '.scss']);
     addCommand(context, ['.html']);
     addCommand(context, ['.js', '.ts']);
+    addCommand(context, ['.ts', '.js']);
 }
 
 function addCommand(context: vscode.ExtensionContext, extensions: string[]) {


### PR DESCRIPTION
Hello,

Currently, `"command": "fileextswitch.js"` switches to .js files.
For projects where `typescript` is compiled to `javascript`, the editor opens the compiled `.js` file.
Whereas the expected behavior is to open the source .ts file.

This pull request makes possible the following binding in `keybindings.json`:
```
    { "key": "ctrl+alt+t",
      "command": "fileextswitch.ts",
      "when": "editorTextFocus"
    }
```

Thank you,
Mykola.