### PR TITLE
Major version bump, cull deprecated commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "file-ext-switcher",
     "displayName": "file-ext-switcher",
     "description": "Quickly switch between different files with the same name before the extension (e.g. angular2 component .ts, .css and .html files).",
-    "version": "2.1.1",
+    "version": "3.0.0",
     "publisher": "JohannesRudolph",
     "engines": {
         "vscode": "^1.8.0"
@@ -26,18 +26,6 @@
             {
                 "command": "fileextswitch",
                 "title": "Switch: to a companion file with the extension specified in the command arguments. Command argument can also control whether to open file in other editor column."
-            },
-            {
-                "command": "fileextswitch.css",
-                "title": "(Deprecated) Switch: to .css or .scss"
-            },
-            {
-                "command": "fileextswitch.html",
-                "title": "(Deprecated) Switch: to .html"
-            },
-            {
-                "command": "fileextswitch.js",
-                "title": "(Deprecated) Switch: to .js or .ts"
             }
         ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,22 +19,9 @@ interface CommandArguments {
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-    addLegacyCommand(context, ['.css', '.scss']);
-    addLegacyCommand(context, ['.html']);
-    addLegacyCommand(context, ['.js', '.ts']);
-
     context.subscriptions.push(
         vscode.commands.registerCommand('fileextswitch', (args: any) => switchToFile(args))
     );
-}
-
-function addLegacyCommand(context: vscode.ExtensionContext, extensions: string[]) {
-    const cmd = 'fileextswitch' + extensions[0]
-    context.subscriptions.push(vscode.commands.registerCommand(cmd, _ => {
-        const warn = `${cmd} is deprecated. Please use the new and more powerful file-ext-switcher configuration: https://goo.gl/gsCYrW `;
-        vscode.window.showWarningMessage(warn);
-        switchToFile({ extensions: extensions });
-    }));
 }
 
 function switchToFile(args: any) {


### PR DESCRIPTION
A major semver bump lets us remove unneeded legacy commands.

This greatly improves the experience when bringing up the Command Palette, since the `(Deprecated)` task descriptions sort near the top of the listed commands.